### PR TITLE
fix(ci): corrige workflow de comunidade para PRs de forks

### DIFF
--- a/.github/workflows/communitty-mgmt.yaml
+++ b/.github/workflows/communitty-mgmt.yaml
@@ -3,7 +3,7 @@ name: Community Management
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
   discussion:
     types: [created]
@@ -14,7 +14,7 @@ jobs:
   welcome-new-contributors:
     name: Welcome New Contributors
     runs-on: ubuntu-latest
-    if: github.event_name == 'issues' || github.event_name == 'pull_request' || github.event_name == 'discussion'
+    if: github.event_name == 'issues' || github.event_name == 'pull_request_target' || github.event_name == 'discussion'
     permissions:
       issues: write
       pull-requests: write
@@ -46,7 +46,7 @@ jobs:
               if (context.eventName === 'issues' && issues.total_count <= 1) {
                 core.setOutput('is-first-issue', true);
               }
-              if (context.eventName === 'pull_request' && prs.total_count <= 1) {
+              if (context.eventName === 'pull_request_target' && prs.total_count <= 1) {
                 core.setOutput('is-first-pr', true);
               }
               
@@ -121,7 +121,7 @@ jobs:
   auto-tag:
     name: Auto Tag Issues and PRs
     runs-on: ubuntu-latest
-    if: github.event_name == 'issues' || github.event_name == 'pull_request'
+    if: github.event_name == 'issues' || github.event_name == 'pull_request_target'
     permissions:
       issues: write
       pull-requests: write
@@ -135,7 +135,7 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const isIssue = context.eventName === 'issues';
-            const isPR = context.eventName === 'pull_request';
+            const isPR = context.eventName === 'pull_request_target';
             const item = isIssue ? context.payload.issue : context.payload.pull_request;
             
             const title = item.title.toLowerCase();
@@ -146,13 +146,13 @@ jobs:
             
             // Type-based labels
             if (isIssue) {
-              if (content.includes('bug') || content.includes('erro') || content.includes('quebra*')) {
+              if (content.includes('bug') || content.includes('erro') || content.includes('quebrado')) {
                 labels.push('bug');
               } else if (content.includes('funcionalidade') || content.includes('melhoria') || content.includes('improvement')) {
                 labels.push('enhancement');
               } else if (content.includes('pergunta') || content.includes('ajuda') || content.includes('how to')) {
                 labels.push('question');
-              } else if (content.includes('documentation') || content.includes('doc*') || content.includes('readme')) {
+              } else if (content.includes('documentation') || content.includes('doc') || content.includes('readme')) {
                 labels.push('documentation');
               }
             }


### PR DESCRIPTION
## Problema

O workflow `.github/workflows/communitty-mgmt.yaml` falha com `X` vermelho em **todo PR aberto por um fork externo**, incluindo contribuidores legítimos.

Erro nos logs:
```
HttpError: Resource not accessible by integration
POST /repos/lhc/infra/issues/45/labels
POST /repos/lhc/infra/issues/45/comments
```

## Causa

O evento `pull_request` executa o workflow no **contexto do fork** (por segurança do GitHub), onde o `GITHUB_TOKEN` é **read-only** e não pode escrever comentários nem adicionar labels no repositório base.

Resultado: os jobs `Welcome New Contributors` e `Auto Tag Issues and PRs` falham em 100% dos PRs externos.

## Correção 1 — `pull_request` → `pull_request_target`

O evento `pull_request_target` executa no **contexto do repositório base**, com `GITHUB_TOKEN` com permissões completas — o padrão recomendado pelo GitHub para workflows de comunidade que precisam escrever em PRs de forks.

```yaml
# ANTES
on:
  pull_request:
    types: [opened]

# DEPOIS
on:
  pull_request_target:
    types: [opened]
```

Todas as referências internas (`if:` dos jobs e `context.eventName` nos scripts JS) foram atualizadas de `pull_request` para `pull_request_target`.

> **Segurança:** os jobs apenas criam comentários e adicionam labels — não fazem checkout de código nem acessam secrets sensíveis, então o uso de `pull_request_target` é seguro aqui.

## Correção 2 — Glob inválido em JavaScript

`String.includes()` busca a **substring literal**, o `*` não funciona como wildcard:

```js
// ANTES — nunca dá match (busca a string literal "quebra*")
content.includes('quebra*')
content.includes('doc*')

// DEPOIS — correto
content.includes('quebrado')
content.includes('doc')
```

## Arquivos alterados

```
.github/workflows/communitty-mgmt.yaml  ← 7 linhas alteradas
```

## Impacto

Após este fix, PRs de forks vão receber corretamente:
- Mensagem de boas-vindas para novos contribuidores
- Labels automáticas (`pr`, `bugfix`, `feature`, etc.)